### PR TITLE
feat: add support for Named Records

### DIFF
--- a/IPNI.md
+++ b/IPNI.md
@@ -292,6 +292,11 @@ Specified protocols are expected to be ordered in increasing order.
 * http
     * the proposed `uvarint` protocol is `0x3D0000`.
     * the following bytes are not yet defined.
+* Named Record
+    * Protocol `uvarint` is <TBD> in the multicodec table
+    * the following bytes should be a dag-cbor encoded struct of:
+        * Name, a string
+        * Record, a valid dag-cbor type
 
 #### ExtendedProvider
 


### PR DESCRIPTION
## Motivation

libp2p protocols have been pretty successful despite there not being a global namespace of protocol IDs. People can just segment them by namespace and develop without requiring a centralized point of friction. This lets people experiment with their own protocols, rename them, modify them, etc. and let the spec evolve more naturally.

Given that there are tons of data transfer protocols that could (and do) exist and people can easily spin up new ones without committing to a global table, it'd be nice for them to be able to use the IPNI as a routing system also without committing to a global table

## Proposal

Have a "protocol" called "Named Record" which is just a combination of Name and Record fields and let people figure plug in whatever they want.

## Impact

Shouldn't change the IPNI protocol itself since it will accept arbitrary metadata bytes. However, it has two advantages:
1. There is a defined way for people to add new protocols without going through the global table for a PR
2. We have a defined way of mapping metadata not currently defined in this document (IPNI.md) to any routing API that is abstracted beyond the IPNI internals of "metadata are arbitrary bytes that may or may not be associated with one or more protocols"