### PR TITLE
Update spec to specify that hex multihash is allowed

### DIFF
--- a/schemas/v1/openapi.yaml
+++ b/schemas/v1/openapi.yaml
@@ -51,7 +51,7 @@ paths:
       parameters:
         - name: multihash
           in: path
-          description: The base58 string representation of the multihash.
+          description: The base58 or hex string representation of the multihash.
           required: true
         - $ref: '#/components/parameters/Cascade'
       responses:


### PR DESCRIPTION
See also:
- https://github.com/ipni/indexstar/pull/190
- https://github.com/ipni/go-libipni/pull/209
